### PR TITLE
externpro 26.01.1-21-g9ce37fe

### DIFF
--- a/.github/release-tag.json
+++ b/.github/release-tag.json
@@ -1,4 +1,4 @@
 {
-  "message": "xpro version 20210625.6 tag",
-  "tag": "xpv20210625.6"
+  "message": "xpro version 20210625.7 tag",
+  "tag": "xpv20210625.7"
 }


### PR DESCRIPTION
## Summary

Update externpro submodule to `26.01.1-21-g9ce37fe`

## Changes

- Updated `.devcontainer` to externpro `26.01.1-21-g9ce37fe`
- Previous HEAD: `a98fa00bf7ceecbc52d54b7fa9670795298ac7ac`
- New HEAD: `9ce37fe8afd8f068bc43fa685566d2a2d84a3028`
- Updated `.github/release-tag.json` (tag: `xpv20210625.7`)
  - Optional: add the "release:tag" label to trigger tagging, release builds, and draft release notes
- If you add the \"release:tag\" label, the tag will be \`xpv20210625.7\`

---

*This PR was created automatically by GitHub Actions*
